### PR TITLE
chore(Cargo.toml): pin libsql-client to rev with sqlite3-parser bumped to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,7 +1917,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -2577,12 +2583,11 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "libsql-client"
 version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad36885b1e43534f5015a8c45a0be4e8a6e9a829bbb3c5704a1c5e0c0fad848"
+source = "git+https://github.com/vdice/libsql-client-rs?branch=chore/bump-deps#f60e71ca91ba6d914d3482a79ba994a7157be0c3"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "futures",
  "hrana-client-proto",
  "num-traits",
@@ -3526,7 +3531,7 @@ dependencies = [
  "base64 0.21.4",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac",
  "md-5",
  "memchr",
@@ -3542,7 +3547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -3930,7 +3935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
  "bitflags 2.4.0",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -4796,13 +4801,13 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlite3-parser"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3995a6daa13c113217b6ad22154865fb06f9cb939bef398fd04f4a7aaaf5bd7"
+checksum = "db68d3f0682b50197a408d65a3246b7d6173399d1325cf0208fb3fdb66e3229f"
 dependencies = [
  "bitflags 2.4.0",
  "cc",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap 1.9.3",
  "log",
  "memchr",
@@ -5168,7 +5173,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ git = "https://github.com/fermyon/bindle"
 tag = "v0.8.2"
 default-features = false
 features = ["client"]
+
+[patch.crates-io]
+# Using fork to bump nested dep sqlite3-parser to 0.9.0 for Windows build fix
+# Pending related upstream PR https://github.com/libsql/libsql-client-rs/pull/32
+libsql-client = { git = "https://github.com/vdice/libsql-client-rs", branch = "chore/bump-deps"}


### PR DESCRIPTION
This should fix the Windows build error seen recently in https://github.com/fermyon/bindle2oci/actions/runs/6521527187/job/17710191186

That error looked familiar; we [hit it in the cloud-plugin a while ago](https://github.com/fermyon/cloud-plugin/actions/runs/5826473375/job/15823056791) and use this same override there.